### PR TITLE
Update cronjob time

### DIFF
--- a/commands/slash/General/getmatches.js
+++ b/commands/slash/General/getmatches.js
@@ -125,9 +125,9 @@ function GetMatches() {
   MessageBuilder(channel);
 }
 
-// runs once a day at specified time 'SS MM HH' - 00:01 default
+// runs once a day at specified time 'SS MM HH' - 02:00 default
 client.once('ready', () => {
-  const scheduledEvent = new cron.CronJob('00 01 00 * * *', () => {
+  const scheduledEvent = new cron.CronJob('00 00 02 * * *', () => {
     GetMatches();
   });
   scheduledEvent.start();


### PR DESCRIPTION
Don't wanna manually run /getmatches anymore. This should allow the matches from the night before to wrap up before running the cronjob, but there will be a black hole of matches between midnight and 2:00am we'll never get (which is fine who even is awake then)